### PR TITLE
Add configurability. Add readme. Fix off by one error on labels.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ typings/
 # DynamoDB Local files
 .dynamodb/
 
+# Build Files
+dist

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+Homebridge HDMI Switch
+====
+
+Introduction
+----
+
+Allows Homebridge to operate a RS232 controlled HDMI Switcher. 
+
+Configuration
+----
+
+Configuration via Homebridge X GUI is provided, but for quick reference, this is what a configured switch would look like:
+
+```
+{
+    "devices": [
+        {
+            "name": "Dev Switcher",
+            "id": "Test0001",
+            "manufacturer": "Test Manufacturer",
+            "path": "/dev/cu.usbserial-145420",
+            "baudRate": 57600,
+            "inputs": 4,
+            "powerOnCommand": "OUTON",
+            "powerOffCommand": "OUTOFF",
+            "outputSelectCommand": "OUT FR %d",
+            "zeroIndexed": false,
+            "commandEnd": "\r",
+            "labels": [
+                "TEST1",
+                "TEST2",
+                "TEST3",
+                "TEST4"
+            ]
+        }
+    ],
+    "platform": "HDMISwitch"
+}
+```

--- a/config.schema.json
+++ b/config.schema.json
@@ -7,45 +7,79 @@
     "properties": {
       "devices": {
         "title": "Devices",
-        "type": "object",
-        "properties": {
-          "name": {
-            "title": "Name",
-            "type": "string",
-            "required": true
-          },
-          "id": {
-            "title": "Identifier",
-            "type": "string",
-            "required": false
-          },
-          "manufacturer": {
-            "title": "Manufacturer",
-            "type": "string",
-            "required": false
-          },
-          "path": {
-            "title": "Port",
-            "type": "string",
-            "required": true
-          },
-          "baudRate": {
-            "title": "Baud Rate",
-            "type": "integer",
-            "required": false
-          },
-          "inputs": {
-            "title": "Number of inputs",
-            "type": "integer",
-            "required": false
-          },
-          "labels": {
-            "title": "Input labels",
-            "type": "array",
-            "required": false,
-            "items": {
-              "title": "Label",
-              "type": "string"
+        "type": "array",
+        "items": {
+          "title": "Device",
+          "type": "object",
+          "properties": {
+            "name": {
+              "title": "Name",
+              "type": "string",
+              "required": true
+            },
+            "id": {
+              "title": "Identifier",
+              "type": "string",
+              "required": false
+            },
+            "manufacturer": {
+              "title": "Manufacturer",
+              "type": "string",
+              "required": false
+            },
+            "path": {
+              "title": "Port",
+              "type": "string",
+              "required": true
+            },
+            "baudRate": {
+              "title": "Baud Rate",
+              "type": "integer",
+              "required": false
+            },
+            "inputs": {
+              "title": "Number of Inputs",
+              "type": "integer",
+              "required": false
+            },
+            "powerOnCommand": {
+              "title": "Power On Command",
+              "type": "string",
+              "required": false,
+              "description": "Provide the command for powering on the switcher."
+            },
+            "powerOffCommand": {
+              "title": "Power Off Command",
+              "type": "string",
+              "required": false,
+              "description": "Provide the command for powering off the switcher."
+            },
+            "outputSelectCommand": {
+              "title": "Output Select Command",
+              "type": "string",
+              "required": false,
+              "description": "Provide the command for switching inputs on the switcher. Use '%d' where the number would go. For example if your documentation asks for 'OUT FR 1' for port 1, use 'OUT FR %d'"
+            },
+            "zeroIndexed": {
+              "title": "Zero Indexed",
+              "type": "boolean",
+              "required": false,
+              "description": "Check this if your RS232 interface asks for ports 1 off from what they are labelled. For example if requesting HDMI 1 requires asking for Port 0."
+            },
+            "commandEnd": {
+              "title": "Command Suffix",
+              "type": "string",
+              "required": false,
+              "description": "This is the suffix for each command. Typically this would be a '\r' or similar to tell the switcher to interpret the command."
+            },
+            "labels": {
+              "title": "Input labels",
+              "type": "array",
+              "required": false,
+              "items": {
+                "title": "Label",
+                "type": "string"
+              }
             }
           }
         }

--- a/src/HDMIConfig.ts
+++ b/src/HDMIConfig.ts
@@ -6,6 +6,11 @@ export interface HDMIConfig extends AccessoryConfig{
     id?: string;
     path: string;
     baudRate?: number;
+    zeroIndexed?: boolean;
+    powerOnCommand?: string;
+    powerOffCommand?: string;
+    outputSelectCommand?: string;
+    commandEnd?: string;
     inputs?: number;
     labels?: string[];
 }


### PR DESCRIPTION
Dependency: https://github.com/emptygalaxy/serial-hdmi-switch/pull/3

Implements new configuration abilities from my other PR.

As well as fixes the ability to configure via Homebridge X GUI, adds some description, and fixes an off-by-one error on the labels.

I'll try to monitor this to the best of my ability, hopefully, this can help someone else too!